### PR TITLE
`which` was missing

### DIFF
--- a/Dockerfiles/e4s-amazonlinux-2.dockerfile
+++ b/Dockerfiles/e4s-amazonlinux-2.dockerfile
@@ -36,6 +36,7 @@ RUN yum update -y \
   tar \
   unzip \
   wget \
+  which \
   xz \
   zlib-devel \
   && localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
Who's on first? What's on second? `which` is missing from Amazon Linux. One package in https://github.com/spack/spack/pull/29522 depends on `which` within a configure script (adlbx).