### PR TITLE
Adding ParallelCluster configuration runner

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -37,7 +37,8 @@ jobs:
                      [tutorial-ubuntu-22.04, tutorial-ubuntu-22.04/Dockerfile, 'linux/amd64'],
                      [e4s-amazonlinux-2, e4s-amazonlinux-2.dockerfile, 'linux/amd64,linux/arm64'],
                      [e4s-centos-7, e4s-centos-7.dockerfile, 'linux/amd64'],
-                     [e4s-fedora-36, e4s-fedora-36.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64']]
+                     [e4s-fedora-36, e4s-fedora-36.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64'],
+                     [pcluster-amazonlinux-2, pcluster-amazonlinux-2.dockerfile, 'linux/amd64,linux/arm64']]
     name: Build ${{ matrix.dockerfile[0] }}
     steps:
       - name: Checkout

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -71,6 +71,7 @@ ENV SLURM_VERSION="22.05.8" \
 RUN mkdir -p /bootstrap && \
     cd /bootstrap && \
     git clone https://github.com/spack/spack spack \
+    && export SPACK_ROOT=/bootstrap/spack \
     && . spack/share/spack/setup-env.sh \
     && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
     && /bin/bash postinstall.sh -fg \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -1,47 +1,48 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 RUN yum update -y \
- && amazon-linux-extras install -y epel \
- && yum update -y \
- && yum install -y \
-  autoconf \
-  automake \
-  bzip2 \
-  cpio \
-  curl \
-  file \
-  findutils \
-  gcc \
-  gcc-c++ \
-  gcc-gfortran \
-  gettext \
-  git \
-  iputils \
-  jq \
-  libffi-devel \
-  glibc-locale-source \
-  m4 \
-  make \
-  mercurial \
-  mlocate \
-  ncurses-devel \
-  openssl-devel \
-  patch \
-  patchelf \
-  pciutils \
-  python3-devel \
-  python3-pip \
-  rsync \
-  tar \
-  unzip \
-  wget \
-  which \
-  xz \
-  zlib-devel \
-  environment-modules \
-  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
-  && yum clean all \
-  && rm -rf /var/cache/yum/*
+    && amazon-linux-extras install -y epel \
+    && yum update -y \
+    && yum install -y \
+    autoconf \
+    automake \
+    bzip2 \
+    cpio \
+    curl \
+    environment-modules \
+    file \
+    findutils \
+    gcc \
+    gcc-c++ \
+    gcc-gfortran \
+    gettext \
+    git \
+    iputils \
+    jq \
+    libffi-devel \
+    libibverbs-core \
+    glibc-locale-source \
+    m4 \
+    make \
+    mercurial \
+    mlocate \
+    ncurses-devel \
+    openssl-devel \
+    patch \
+    patchelf \
+    pciutils \
+    python3-devel \
+    python3-pip \
+    rsync \
+    tar \
+    unzip \
+    wget \
+    which \
+    xz \
+    zlib-devel \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
 
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install gnureadline 'boto3<=1.20.35' 'botocore<=1.23.46' pyyaml pytz minio requests clingo \
@@ -71,8 +72,8 @@ RUN mkdir -p /bootstrap && \
     cd /bootstrap && \
     git clone https://github.com/spack/spack spack \
     && . spack/share/spack/setup-env.sh \
-    && curl -sL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
-    | sed -e '/nohup/s/&$//' -e 's/nohup//' | /bin/bash \
+    && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
+    && /bin/bash postinstall.sh -fg \
     && spack clean -a \
     && cd /bootstrap/spack \
     && find . -type f -maxdepth 1 -delete \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -60,7 +60,7 @@ RUN git clone https://github.com/spack/spack /spack \
 
 # TODO Get from /opt if we are building this on top of Pcluster AMI
 # If not then use hard coded values. These are for ParallelCluster-3.5.1
-RUN echo "3.5.1" > /opt/parallelcluster/.bootstrapped
+RUN mkdir -p /opt/parallelcluster && echo "3.5.1" > /opt/parallelcluster/.bootstrapped
 ENV SLURM_VERSION="22.05.8" \
     LIBFABRIC_MODULE_VERSION="1.17.0" \
     LIBFABRIC_MODULE="libfabric-aws/${LIBFABRIC_MODULE_VERSION}" \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /bootstrap && \
     && export SPACK_ROOT=/bootstrap/spack \
     && . spack/share/spack/setup-env.sh \
     && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
-    && /bin/bash postinstall.sh -fg \
+    && /bin/bash postinstall.sh -fg -nointel \
     && spack clean -a \
     && cd /bootstrap/spack \
     && find . -type f -maxdepth 1 -delete \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -64,7 +64,7 @@ RUN git clone https://github.com/spack/spack /spack \
 RUN mkdir -p /opt/parallelcluster && echo "3.5.1" > /opt/parallelcluster/.bootstrapped
 ENV SLURM_VERSION="22.05.8" \
     LIBFABRIC_MODULE_VERSION="1.17.0" \
-    LIBFABRIC_MODULE="libfabric-aws/${LIBFABRIC_MODULE_VERSION}" \
+    LIBFABRIC_MODULE="libfabric-aws/1.17.0" \
     LIBFABRIC_VERSION="1.17.0" \
     GCC_VERSION="7.3.1"
 

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -1,0 +1,89 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+RUN yum update -y \
+ && amazon-linux-extras install -y epel \
+ && yum update -y \
+ && yum install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  cpio \
+  curl \
+  file \
+  findutils \
+  gcc \
+  gcc-c++ \
+  gcc-gfortran \
+  gettext \
+  git \
+  iputils \
+  jq \
+  libffi-devel \
+  glibc-locale-source \
+  m4 \
+  make \
+  mercurial \
+  mlocate \
+  ncurses-devel \
+  openssl-devel \
+  patch \
+  patchelf \
+  pciutils \
+  python3-devel \
+  python3-pip \
+  rsync \
+  tar \
+  unzip \
+  wget \
+  which \
+  xz \
+  zlib-devel \
+  environment-modules \
+  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+  && yum clean all \
+  && rm -rf /var/cache/yum/*
+
+RUN python3 -m pip install --upgrade pip setuptools wheel \
+ && python3 -m pip install gnureadline 'boto3<=1.20.35' 'botocore<=1.23.46' pyyaml pytz minio requests clingo \
+ && rm -rf ~/.cache
+
+COPY gpg.yaml /spack.yaml
+RUN git clone https://github.com/spack/spack /spack \
+ && (cd /spack && curl -Lfs https://github.com/spack/spack/pull/37405.patch | patch -p1) \
+ && export SPACK_ROOT=/spack \
+ && . /spack/share/spack/setup-env.sh \
+ && spack -e . concretize \
+ && spack -e . install --make \
+ && spack -e . gc -y \
+ && spack clean -a \
+ && rm -rf /spack /spack.yaml /spack.lock /.spack-env /root/.spack
+
+# TODO Get from /opt if we are building this on top of Pcluster AMI
+# If not then use hard coded values. These are for ParallelCluster-3.5.1
+RUN echo "3.5.1" > /opt/parallelcluster/.bootstrapped
+ENV SLURM_VERSION="22.05.8" \
+    LIBFABRIC_MODULE_VERSION="1.17.0" \
+    LIBFABRIC_MODULE="libfabric-aws/${LIBFABRIC_MODULE_VERSION}" \
+    LIBFABRIC_VERSION="1.17.0" \
+    GCC_VERSION="7.3.1"
+
+RUN mkdir -p /bootstrap && \
+    cd /bootstrap && \
+    git clone https://github.com/spack/spack spack \
+    && . spack/share/spack/setup-env.sh \
+    && curl -sL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
+    | sed -e '/nohup/s/&$//' -e 's/nohup//' | /bin/bash \
+    && spack clean -a \
+    && cd /bootstrap/spack \
+    && find . -type f -maxdepth 1 -delete \
+    && rm -rf bin lib share var /root/.spack
+
+ENV PATH=/bootstrap/runner/view/bin:$PATH \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LANGUAGE=en_US:en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+CMD ["/bin/bash"]
+

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -18,9 +18,12 @@ RUN yum update -y \
     gettext \
     git \
     iputils \
+    jansson-devel \
     jq \
+    libevent-devel \
     libffi-devel \
     libibverbs-core \
+    libtool \
     glibc-locale-source \
     m4 \
     make \
@@ -31,6 +34,7 @@ RUN yum update -y \
     patch \
     patchelf \
     pciutils \
+    perl-devel\
     python3-devel \
     python3-pip \
     rsync \
@@ -59,15 +63,53 @@ RUN git clone https://github.com/spack/spack /spack \
  && spack clean -a \
  && rm -rf /spack /spack.yaml /spack.lock /.spack-env /root/.spack
 
-# TODO Get from /opt if we are building this on top of Pcluster AMI
-# If not then use hard coded values. These are for ParallelCluster-3.5.1
-RUN mkdir -p /opt/parallelcluster && echo "3.5.1" > /opt/parallelcluster/.bootstrapped
-ENV SLURM_VERSION="22.05.8" \
-    LIBFABRIC_MODULE_VERSION="1.17.0" \
-    LIBFABRIC_MODULE="libfabric-aws/1.17.0" \
-    LIBFABRIC_VERSION="1.17.0" \
-    GCC_VERSION="7.3.1"
+ENV PCLUSTER_VERSION="3.5.1" \
+    LIBJWT_VERSION="1.12.0" \
+    PMIX_VERSION="3.2.3" \
+    SLURM_VERSION="22-05-8-1" \
+    EFA_INSTALLER_VERSION="1.22.0"
 
+# Install SLURM and libfabric as on ParalleCluster itself
+RUN mkdir -p /opt/parallelcluster && echo "${PCLUSTER_VERSION}" > /opt/parallelcluster/.bootstrapped
+
+RUN curl -sOL https://github.com/benmcollins/libjwt/archive/refs/tags/v${LIBJWT_VERSION}.tar.gz \
+    && tar xf v${LIBJWT_VERSION}.tar.gz \
+    && cd libjwt-${LIBJWT_VERSION}/ \
+    && autoreconf --force --install \
+    && ./configure --prefix=/opt/libjwt \
+    && make -j \
+    && make install && make clean \
+    && cd .. \
+    && rm -rf v${LIBJWT_VERSION}.tar.gz libjwt-${LIBJWT_VERSION}
+
+RUN curl -sOL https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION}/pmix-${PMIX_VERSION}.tar.gz \
+    && tar xf pmix-${PMIX_VERSION}.tar.gz \
+    && cd pmix-${PMIX_VERSION} \
+    && ./autogen.pl \
+    && ./configure --prefix=/opt/pmix \
+    && make -j \
+    && make install && make clean \
+    && cd .. \
+    && rm -rf pmix-${PMIX_VERSION}.tar.gz pmix-${PMIX_VERSION}
+
+# Actual PCluster also configures `--enable-slurmrestd`
+RUN curl -sOL https://github.com/SchedMD/slurm/archive/slurm-${SLURM_VERSION}.tar.gz \
+    && tar xf slurm-${SLURM_VERSION}.tar.gz \
+    && cd slurm-slurm-${SLURM_VERSION}/ \
+    && ./configure --prefix=/opt/slurm --with-pmix=/opt/pmix --with-jwt=/opt/libjwt \
+    && make -j \
+    && make install && make install-contrib && make clean \
+    && cd .. \
+    && rm -rf slurm-${SLURM_VERSION}.tar.gz slurm-slurm-${SLURM_VERSION}
+
+RUN curl -sOL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
+    && tar xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
+    && cd aws-efa-installer \
+    && ./efa_installer.sh -y -k \
+    && cd .. \
+    && rm -rf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz aws-efa-installer
+
+# Bootstrap spack compiler installation
 RUN mkdir -p /bootstrap && \
     cd /bootstrap && \
     git clone https://github.com/spack/spack spack \
@@ -88,4 +130,3 @@ ENV PATH=/bootstrap/runner/view/bin:$PATH \
     LC_ALL=en_US.UTF-8
 
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
This runner builds GCC & OneApi compilers and will be used in CI stack `aws-pcluster` to build the packages defined in
https://github.com/spack/spack-configs/tree/main/AWS/parallelcluster.