### PR TITLE
[pcluster-amazon-linux2] Use a local buildcache instead of upstream

### DIFF
--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -115,9 +115,9 @@ RUN mkdir -p /bootstrap && \
     git clone https://github.com/spack/spack spack \
     && export SPACK_ROOT=/bootstrap/spack \
     && . spack/share/spack/setup-env.sh \
+    && spack config add config:install_tree:padded_length:256 \
     && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
     && /bin/bash postinstall.sh -fg -nointel \
-    && spack config add config:install_tree:padded_length:256 \
     && spack gpg init \
     && spack gpg create local-cache no@email.com \
     && spack buildcache create -a /bootstrap/local-cache $(spack find --format '/{hash}') \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -117,6 +117,7 @@ RUN mkdir -p /bootstrap && \
     && . spack/share/spack/setup-env.sh \
     && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
     && /bin/bash postinstall.sh -fg -nointel \
+    && spack config add config:install_tree:padded_length:256 \
     && spack gpg init \
     && spack gpg create local-cache no@email.com \
     && spack buildcache create -a /bootstrap/local-cache $(spack find --format '/{hash}') \

--- a/Dockerfiles/pcluster-amazonlinux-2.dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2.dockerfile
@@ -117,10 +117,12 @@ RUN mkdir -p /bootstrap && \
     && . spack/share/spack/setup-env.sh \
     && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
     && /bin/bash postinstall.sh -fg -nointel \
-    && spack clean -a \
-    && cd /bootstrap/spack \
-    && find . -type f -maxdepth 1 -delete \
-    && rm -rf bin lib share var /root/.spack
+    && spack gpg init \
+    && spack gpg create local-cache no@email.com \
+    && spack buildcache create -a /bootstrap/local-cache $(spack find --format '/{hash}') \
+    && spack gpg export /bootstrap/public-key local-cache \
+    && cd /bootstrap \
+    && rm -rf spack
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \


### PR DESCRIPTION
Spack currently does not relocate compiler references from upstream spack
installations. When using a buildcache we don't need an upstream spack.
