### PR TITLE
[aws=pcluster] Install compilers into spack store

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -40,7 +40,7 @@ jobs:
                      [e4s-amazonlinux-2, e4s-amazonlinux-2.dockerfile, 'linux/amd64,linux/arm64'],
                      [e4s-centos-7, e4s-centos-7.dockerfile, 'linux/amd64'],
                      [e4s-fedora-36, e4s-fedora-36.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64'],
-                     [pcluster-amazonlinux-2, pcluster-amazonlinux-2.dockerfile, 'linux/amd64,linux/arm64']]
+                     [pcluster-amazonlinux-2, pcluster-amazonlinux-2/Dockerfile, 'linux/amd64,linux/arm64']]
     name: Build ${{ matrix.dockerfile[0] }}
     steps:
       - name: Checkout

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -109,18 +109,23 @@ RUN curl -sOL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTAL
     && cd .. \
     && rm -rf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz aws-efa-installer
 
-# Bootstrap spack compiler installation
-RUN mkdir -p /bootstrap && \
-    cd /bootstrap && \
-    git clone https://github.com/spack/spack spack \
-    && export SPACK_ROOT=/bootstrap/spack \
-    && . spack/share/spack/setup-env.sh \
-    && curl -sOL https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/postinstall.sh \
-    && /bin/bash postinstall.sh -fg -nointel \
-    && spack clean -a \
-    && cd /bootstrap/spack \
-    && find . -type f -maxdepth 1 -delete \
-    && rm -rf bin lib share var /root/.spack
+# Bootstrap spack compiler installation into the eventual installation tree
+# Defined in spack/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+ARG SPACK_ROOT="/bootstrap-compilers/spack"
+#  commit after https://github.com/spack/spack/pull/34821
+ARG SPACK_COMMIT=f27d012
+ARG TARGETARCH
+COPY Dockerfiles/pcluster-amazonlinux-2/packages-${TARGETARCH}.yaml /root/.spack/packages.yaml
+RUN mkdir -p $(dirname "${SPACK_ROOT}") \
+    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
+    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "${SPACK_ROOT}/etc/spack/config.yaml" \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && spack compiler add \
+    && spack external find \
+    && spack tags build-tools | xargs -I {} spack config rm packages:{} \
+    && spack install gcc \
+    && $(dirname "${SPACK_ROOT}") /root/.spack/packages.yaml
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -125,7 +125,7 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack external find \
     && spack tags build-tools | xargs -I {} spack config rm packages:{} \
     && spack install gcc \
-    && $(dirname "${SPACK_ROOT}") /root/.spack/packages.yaml
+    && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack/packages.yaml
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/Dockerfiles/pcluster-amazonlinux-2/packages-amd64.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/packages-amd64.yaml
@@ -1,0 +1,6 @@
+---  # GCC setup for all AMD64 based targets
+packages:
+  gcc:
+    compiler: [gcc]
+    require:
+      - one_of: ["gcc@12 +binutils ^binutils@2.37 target=x86_64_v3"]

--- a/Dockerfiles/pcluster-amazonlinux-2/packages-arm64.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/packages-arm64.yaml
@@ -1,0 +1,6 @@
+---  # GCC setup for all ARM64 based targets
+packages:
+  gcc:
+    compiler: [gcc]
+    require:
+      - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]


### PR DESCRIPTION
This is the same installation location where spack pipelines will build. This enables the prefix location to relocate the compiler paths in the apps correctly. Also, postinstall.sh will install gcc from hash, so there is no risk that gcc will build from source in the pipeline.