### PR TITLE
Sign the gcc bootstrap cache and add pub-key as artifact

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -101,11 +101,13 @@ jobs:
           id=$(docker create --platform linux/amd64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-x86_64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-x86_64
+          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-x86_64.pub
           docker rm -v $id
 
           id=$(docker create --platform linux/arm64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-aarch64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-aarch64
+          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-aarch64.pub
           docker rm -v $id
 
       - uses: actions/upload-artifact@v3
@@ -118,3 +120,13 @@ jobs:
           name: bootstrap-gcc-cache-aarch64
           path: |
             bootstrap-gcc-cache-aarch64
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-gcc-x86_64.pub
+          path: |
+            bootstrap-gcc-x86_64.pub
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-gcc-aarch64.pub
+          path: |
+            bootstrap-gcc-aarch64.pub

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -129,6 +129,19 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
+ARG KEYNAME=bootstrap-gcc
+# Sign the buildcache
+RUN mkdir -p $(dirname "${SPACK_ROOT}") \
+    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
+    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && mkdir -p /bootstrap-gcc-cache/build_cache/_pgp \
+    && spack gpg create --export /bootstrap-gcc-cache/build_cache/_pgp/${KEYNAME}.pub ${KEYNAME} stesachs@amazon.com \
+    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${KEYNAME} --clearsign {} \
+    && echo "{\"keys\":{\"${KEYNAME}\":{}}}" > /bootstrap-gcc-cache/build_cache/_pgp/index.json \
+    && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
+    && spack buildcache rebuild-index bootstrap-gcc-cache
+
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility \


### PR DESCRIPTION
This signed cache can later be uploaded to a public place and used to bootstrap the compiler installation when using [pcluster postinstall script](https://github.com/spack/spack-configs/blob/main/AWS/parallelcluster/postinstall.sh).