### PR TITLE
Sign the gcc bootstrap cache and add pub-key as artifact

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -90,6 +90,7 @@ jobs:
     needs: [ deploy-images ]
     env:
       CONTAINER_NAME: 'ghcr.io/spack/pcluster-amazonlinux-2'
+      KEY_FINGERPRINT: '5195AD463E705FC2014BFF08FE8754F9EEC75620'
     steps:
       - name: Get Container Tag
         id: meta
@@ -103,13 +104,12 @@ jobs:
           id=$(docker create --platform linux/amd64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-x86_64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-x86_64
-          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-x86_64.pub
+          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/${KEY_FINGERPRINT}.pub ${KEY_FINGERPRINT}.pub
           docker rm -v $id
 
           id=$(docker create --platform linux/arm64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-aarch64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-aarch64
-          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-aarch64.pub
           docker rm -v $id
 
       - uses: actions/upload-artifact@v3
@@ -124,11 +124,6 @@ jobs:
             bootstrap-gcc-cache-aarch64
       - uses: actions/upload-artifact@v3
         with:
-          name: bootstrap-gcc-x86_64.pub
+          name: ${{ env.KEY_FINGERPRINT }}.pub
           path: |
-            bootstrap-gcc-x86_64.pub
-      - uses: actions/upload-artifact@v3
-        with:
-          name: bootstrap-gcc-aarch64.pub
-          path: |
-            bootstrap-gcc-aarch64.pub
+             ${KEY_FINGERPRINT}.pub

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -79,7 +79,8 @@ jobs:
             ghcr.io/spack/${{ matrix.dockerfile[0] }}:latest
             ${{ steps.meta.outputs.tags }}
           cache-to: type=inline
-          secrets: BOOTSTRAP_GCC_KEY=${{ secrets.BOOTSTRAP_GCC_KEY }}
+          secrets: |
+            "BOOTSTRAP_GCC_KEY=${{ secrets.BOOTSTRAP_GCC_KEY }}"
 
   upload-gcc-buildcache:
     timeout-minutes: 60

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -80,7 +80,7 @@ jobs:
             ${{ steps.meta.outputs.tags }}
           cache-to: type=inline
           secrets: |
-            "BOOTSTRAP_GCC_KEY=${{ secrets.BOOTSTRAP_GCC_KEY }}"
+            "bootstrap_gcc_key=${{ secrets.BOOTSTRAP_GCC_KEY }}"
 
   upload-gcc-buildcache:
     timeout-minutes: 60

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -79,7 +79,7 @@ jobs:
             ghcr.io/spack/${{ matrix.dockerfile[0] }}:latest
             ${{ steps.meta.outputs.tags }}
           cache-to: type=inline
-          secrets: BOOTSTRAP_GCC_KEY=${{ secrets.bootstrap_gcc_key }}
+          secrets: BOOTSTRAP_GCC_KEY=${{ secrets.BOOTSTRAP_GCC_KEY }}
 
   upload-gcc-buildcache:
     timeout-minutes: 60

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -101,11 +101,13 @@ jobs:
           id=$(docker create --platform linux/amd64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-x86_64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-x86_64
+          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-x86_64.pub
           docker rm -v $id
 
           id=$(docker create --platform linux/arm64 ${CONTAINER_TAG})
           mkdir bootstrap-gcc-cache-aarch64
           docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-aarch64
+          docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/bootstrap-gcc.pub bootstrap-gcc-aarch64.pub
           docker rm -v $id
 
       - uses: actions/upload-artifact@v3
@@ -118,3 +120,13 @@ jobs:
           name: bootstrap-gcc-cache-aarch64
           path: |
             bootstrap-gcc-cache-aarch64
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-gcc-x86_64.pub
+          path: |
+            bootstrap-gcc-x86_64.pub
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-gcc-aarch64.pub
+          path: |
+            bootstrap-gcc-aarch64.pub

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -79,6 +79,7 @@ jobs:
             ghcr.io/spack/${{ matrix.dockerfile[0] }}:latest
             ${{ steps.meta.outputs.tags }}
           cache-to: type=inline
+          secrets: BOOTSTRAP_GCC_KEY=${{ secrets.bootstrap_gcc_key }}
 
   upload-gcc-buildcache:
     timeout-minutes: 60

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -97,33 +97,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.CONTAINER_NAME }}
-      - uses: actions/checkout@v4
-      - env:
+      - name: Checkout Container
+        uses: actions/checkout@v4
+      - name: Copy from container to local disk
+        env:
           CONTAINER_TAG: ${{ steps.meta.outputs.tags }}
         run: |
           id=$(docker create --platform linux/amd64 ${CONTAINER_TAG})
-          mkdir bootstrap-gcc-cache-x86_64
-          docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-x86_64
           docker cp $id:/bootstrap-gcc-cache/build_cache/_pgp/${KEY_FINGERPRINT}.pub ${KEY_FINGERPRINT}.pub
           docker rm -v $id
 
-          id=$(docker create --platform linux/arm64 ${CONTAINER_TAG})
-          mkdir bootstrap-gcc-cache-aarch64
-          docker cp $id:/bootstrap-gcc-cache bootstrap-gcc-cache-aarch64
-          docker rm -v $id
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: bootstrap-gcc-cache-x86_64
-          path: |
-            bootstrap-gcc-cache-x86_64
-      - uses: actions/upload-artifact@v3
-        with:
-          name: bootstrap-gcc-cache-aarch64
-          path: |
-            bootstrap-gcc-cache-aarch64
-      - uses: actions/upload-artifact@v3
+      - name: Upload public key to Github artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.KEY_FINGERPRINT }}.pub
-          path: |
-             ${KEY_FINGERPRINT}.pub
+          path: ${{ env.KEY_FINGERPRINT }}.pub

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -137,7 +137,7 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
     && spack gpg trust ${secretkey_file} \
     && rm ${secretkey_file} \
-    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colon | awk -F: '/fpr/{print $10}')
+    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colon | awk -F: '/fpr/{print $10}') \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
     && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -128,18 +128,20 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
-ARG KEYNAME=bootstrap-gcc
 # Sign the buildcache
+ARG KEYNAME=947B69BDF884C3F6F71046D4C6E606E635F81287
+
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
-    && mkdir -p /bootstrap-gcc-cache/build_cache/_pgp \
-    && spack gpg create --export /bootstrap-gcc-cache/build_cache/_pgp/${KEYNAME}.pub ${KEYNAME} stesachs@amazon.com \
+    && secretkey_file=$(mktemp) \
+    && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
+    && spack gpg trust ${secretkey_file} \
+    && rm ${secretkey_file} \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${KEYNAME} --clearsign {} \
-    && echo "{\"keys\":{\"${KEYNAME}\":{}}}" > /bootstrap-gcc-cache/build_cache/_pgp/index.json \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
-    && spack buildcache rebuild-index bootstrap-gcc-cache
+    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${KEYNAME}
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -134,7 +134,6 @@ RUN --mount=type=secret,id=bootstrap_gcc_key \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
-    && secretkey_file=$(mktemp) \
     && wc /run/secrets/bootstrap_gcc_key \
     && spack gpg trust /run/secrets/bootstrap_gcc_key \
     && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -129,12 +129,13 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 # Sign the buildcache
+ARG BOOTSTRAP_GCC_KEY
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && secretkey_file=$(mktemp) \
-    && echo -e "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
+    && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
     && wc ${secretkey_file} \
     && spack gpg trust ${secretkey_file} \
     && rm ${secretkey_file} \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -128,6 +128,19 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
+ARG KEYNAME=bootstrap-gcc
+# Sign the buildcache
+RUN mkdir -p $(dirname "${SPACK_ROOT}") \
+    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
+    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && mkdir -p /bootstrap-gcc-cache/build_cache/_pgp \
+    && spack gpg create --export /bootstrap-gcc-cache/build_cache/_pgp/${KEYNAME}.pub ${KEYNAME} stesachs@amazon.com \
+    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${KEYNAME} --clearsign {} \
+    && echo "{\"keys\":{\"${KEYNAME}\":{}}}" > /bootstrap-gcc-cache/build_cache/_pgp/index.json \
+    && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
+    && spack buildcache rebuild-index bootstrap-gcc-cache
+
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -141,7 +141,8 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && rm ${secretkey_file} \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${KEYNAME} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
-    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${KEYNAME}
+    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${KEYNAME} \
+    && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -134,7 +134,6 @@ RUN --mount=type=secret,id=bootstrap_gcc_key \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
-    && wc /run/secrets/bootstrap_gcc_key \
     && spack gpg trust /run/secrets/bootstrap_gcc_key \
     && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -129,8 +129,6 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 # Sign the buildcache
-ARG KEYNAME=947B69BDF884C3F6F71046D4C6E606E635F81287
-
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
@@ -139,9 +137,10 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
     && spack gpg trust ${secretkey_file} \
     && rm ${secretkey_file} \
-    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${KEYNAME} --clearsign {} \
+    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colon | awk -F: '/fpr/{print $10}')
+    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
-    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${KEYNAME} \
+    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -134,10 +134,11 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && secretkey_file=$(mktemp) \
-    && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
+    && echo -e "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
+    && wc ${secretkey_file} \
     && spack gpg trust ${secretkey_file} \
     && rm ${secretkey_file} \
-    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colon | awk -F: '/fpr/{print $10}') \
+    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
     && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -129,16 +129,14 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 # Sign the buildcache
-ARG BOOTSTRAP_GCC_KEY
-RUN mkdir -p $(dirname "${SPACK_ROOT}") \
+RUN --mount=type=secret,id=bootstrap_gcc_key \
+    mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
     && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && secretkey_file=$(mktemp) \
-    && echo "${BOOTSTRAP_GCC_KEY}" > ${secretkey_file} \
-    && wc ${secretkey_file} \
-    && spack gpg trust ${secretkey_file} \
-    && rm ${secretkey_file} \
+    && wc /run/secrets/bootstrap_gcc_key \
+    && spack gpg trust /run/secrets/bootstrap_gcc_key \
     && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \

--- a/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
@@ -2,4 +2,4 @@
 packages:
   gcc:
     compiler: [gcc]
-    require: "gcc@12 +binutils ^binutils@2.37 target=x86_64_v3"
+    require: "gcc@12 +strip +binutils ^binutils@2.37 target=x86_64_v3"

--- a/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
@@ -2,4 +2,4 @@
 packages:
   gcc:
     compiler: [gcc]
-    require: "gcc@12 +binutils ^binutils@2.37 target=aarch64"
+    require: "gcc@12 +strip +binutils ^binutils@2.37 target=aarch64"


### PR DESCRIPTION
This signed cache can later be uploaded to a public place and used to bootstrap the compiler installation when using [pcluster postinstall script](https://github.com/spack/spack-configs/blob/main/AWS/parallelcluster/postinstall.sh).