### PR TITLE
Remove `spack --make` as the patch cannot be applied anymore

### DIFF
--- a/Dockerfiles/e4s-amazonlinux-2.dockerfile
+++ b/Dockerfiles/e4s-amazonlinux-2.dockerfile
@@ -48,11 +48,10 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 
 COPY gpg.yaml /spack.yaml
 RUN git clone https://github.com/spack/spack /spack \
- && (cd /spack && curl -Lfs https://github.com/spack/spack/pull/37405.patch | patch -p1) \
- && export SPACK_ROOT=/spack \
+  && export SPACK_ROOT=/spack \
  && . /spack/share/spack/setup-env.sh \
  && spack -e . concretize \
- && spack -e . install --make \
+ && spack -e . install \
  && spack -e . gc -y \
  && spack clean -a \
  && rm -rf /spack /spack.yaml /spack.lock /.spack-env /root/.spack

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -54,11 +54,10 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 
 COPY gpg.yaml /spack.yaml
 RUN git clone https://github.com/spack/spack /spack \
- && (cd /spack && curl -Lfs https://github.com/spack/spack/pull/37405.patch | patch -p1) \
  && export SPACK_ROOT=/spack \
  && . /spack/share/spack/setup-env.sh \
  && spack -e . concretize \
- && spack -e . install --make \
+ && spack -e . install \
  && spack -e . gc -y \
  && spack clean -a \
  && rm -rf /spack /spack.yaml /spack.lock /.spack-env /root/.spack


### PR DESCRIPTION
https://github.com/spack/spack/pull/37405 cannot be applied as a patch to curreent spack develop branch anymore. As this only speeds up the installation process, it is safe to remove.