### PR TITLE
[pcluster] Add index.json and move 'compiler:' to comply with v0.22

### DIFF
--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -139,6 +139,7 @@ RUN --mount=type=secret,id=bootstrap_gcc_key \
     && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
     && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
     && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \
+    && spack buildcache rebuild-index bootstrap-gcc-cache \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \

--- a/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
@@ -1,5 +1,6 @@
 ---  # GCC setup for all AMD64 based targets
 packages:
   gcc:
-    compiler: [gcc]
     require: "gcc@12 +strip +binutils ^binutils@2.37 target=x86_64_v3"
+  all:
+    compiler: [gcc]

--- a/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
@@ -1,5 +1,6 @@
 ---  # GCC setup for all ARM64 based targets
 packages:
   gcc:
-    compiler: [gcc]
     require: "gcc@12 +strip +binutils ^binutils@2.37 target=aarch64"
+  all:
+    compiler: [gcc]


### PR DESCRIPTION
- We need to run `rebuild-index` once at the end in order to create the `index.json` necessary when using this as remote buildcache.

- Move the 'compiler:' requirement to the `alla` section in order to comply with v0.22. This only affects installing the compiler.