### PR TITLE
Create image for use in ML pipelines

### DIFF
--- a/Dockerfiles/ubuntu-22.04.dockerfile
+++ b/Dockerfiles/ubuntu-22.04.dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt update -y \
+  && apt upgrade -y \
+  && apt install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  cpio \
+  curl \
+  file \
+  findutils \
+  g++ \
+  gcc \
+  gettext \
+  gfortran \
+  git \
+  gpg \
+  iputils-ping \
+  jq \
+  libffi-dev \
+  libssl-dev \
+  libxml2-dev \
+  locales \
+  locate \
+  m4 \
+  make \
+  mercurial \
+  ncurses-dev \
+  patch \
+  patchelf \
+  pciutils \
+  python3-pip \
+  rsync \
+  unzip \
+  wget \
+  zlib1g-dev \
+  && locale-gen en_US.UTF-8 \
+  && apt autoremove --purge \
+  && apt clean \
+  && ln -s /usr/bin/gpg /usr/bin/gpg2 \
+  && ln -s `which python3` /usr/bin/python
+
+RUN python -m pip install --upgrade pip setuptools wheel \
+ && python -m pip install gnureadline boto3 pyyaml pytz minio requests clingo \
+ && rm -rf ~/.cache
+
+CMD ["/bin/bash"]
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LANGUAGE=en_US:en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8


### PR DESCRIPTION
The idea is to create an image that can be used across all Linux ML pipelines (x86_64, aarch64, ppc64le) with a newer OS/GCC version. Some criteria:

1. TF requires GCC 9.4+
1. TF requires `/usr/bin/python3`
2. TF requires ROCm to be installed in a specific system directory

I'm hoping we get 1 and 2 out of the box. I don't know how to get 3.

Is there a way to do the same for macOS? Not sure where those CI images live...

P.S. I don't know how to write or test a Dockerfile so if you have any suggestions, it's probably quicker to push to my branch than it is to explain it to me 😅 