### PR TITLE
Create image for use in ML pipelines

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         dockerfile: [[e4s-ubuntu-18.04, e4s-ubuntu-18.04.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64'],
                      [e4s-ubuntu-20.04, e4s-ubuntu-20.04.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64'],
+                     [ubuntu-22.04, ubuntu-22.04.dockerfile, 'linux/amd64,linux/ppc64le,linux/arm64'],
                      [linux-ubuntu22.04-x86_64_v2, linux-ubuntu22.04-x86_64_v2/Dockerfile, 'linux/amd64'],
                      [tutorial-ubuntu-22.04, tutorial-ubuntu-22.04/Dockerfile, 'linux/amd64'],
                      [e4s-amazonlinux-2, e4s-amazonlinux-2.dockerfile, 'linux/amd64,linux/arm64'],

--- a/Dockerfiles/ubuntu-22.04.dockerfile
+++ b/Dockerfiles/ubuntu-22.04.dockerfile
@@ -34,7 +34,6 @@ RUN apt update -y \
   patchelf \
   pciutils \
   python3-pip \
-  rocm \
   rsync \
   unzip \
   wget \

--- a/Dockerfiles/ubuntu-22.04.dockerfile
+++ b/Dockerfiles/ubuntu-22.04.dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt update -y \
+  && apt upgrade -y \
+  && apt install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  cpio \
+  curl \
+  file \
+  findutils \
+  g++ \
+  gcc \
+  gettext \
+  gfortran \
+  git \
+  gpg \
+  iputils-ping \
+  jq \
+  libffi-dev \
+  libssl-dev \
+  libxml2-dev \
+  locales \
+  locate \
+  m4 \
+  make \
+  mercurial \
+  ncurses-dev \
+  patch \
+  patchelf \
+  pciutils \
+  python3-pip \
+  rsync \
+  unzip \
+  wget \
+  zlib1g-dev \
+  && locale-gen en_US.UTF-8 \
+  && apt autoremove --purge \
+  && apt clean \
+  && ln -s /usr/bin/gpg /usr/bin/gpg2 \
+  && ln -s `which python3` /usr/bin/python
+
+RUN python -m pip install --upgrade pip setuptools wheel \
+ && python -m pip install gnureadline boto3 pyyaml pytz minio requests clingo \
+ && rm -rf ~/.cache
+
+CMD ["/bin/bash"]
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LANGUAGE=en_US:en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8

--- a/Dockerfiles/ubuntu-22.04.dockerfile
+++ b/Dockerfiles/ubuntu-22.04.dockerfile
@@ -34,6 +34,7 @@ RUN apt update -y \
   patchelf \
   pciutils \
   python3-pip \
+  rocm \
   rsync \
   unzip \
   wget \


### PR DESCRIPTION
The idea is to create an image that can be used across all Linux ML pipelines (x86_64, aarch64, ppc64le) with a newer OS/GCC version. Some criteria:

1. TF requires GCC 9.4+
1. TF requires `/usr/bin/python3`
2. TF requires ROCm to be installed in a specific system directory

P.S. I don't know how to write or test a Dockerfile so if you have any suggestions, it's probably quicker to push to my branch than it is to explain it to me 😅 