### PR TITLE
Add intel-oneapi-compiler into pcluster image

### DIFF
--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -148,6 +148,7 @@ RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}"
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'conda_channel') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'debugger') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name '*32*') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'oclfpga') \
     && rm -rf /opt/intel /tmp/*
     && spack clean -a \
     && rm -rf /root/.spack ; fi

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -149,7 +149,7 @@ RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}"
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'debugger') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name '*32*') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'oclfpga') \
-    && rm -rf /opt/intel /tmp/*
+    && rm -rf /opt/intel /tmp/* \
     && spack clean -a \
     && rm -rf /root/.spack ; fi
 

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -128,6 +128,30 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
+# Add intel compiler by using a constant git tag. Leave the spack installation to enable
+# `spack install intel-oneapi-compiler` during container bootstrap.
+ARG SPACK_ROOT="/bootstrap-compilers/spack"
+ARG SPACK_TAG="develop-2023-08-06"
+COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
+RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}") \
+    && git clone --depth=1 -b ${SPACK_TAG} https://github.com/spack/spack.git "${SPACK_ROOT}" \
+    && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "${SPACK_ROOT}/etc/spack/config.yaml" \
+    && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "/bootstrap/cloud_pipelines-config.yaml" \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && spack load gcc \
+    && spack compiler add --scope site \
+    && spack external find --scope site --tag core-packages \
+    && cd "${SPACK_ROOT}" \
+    && curl -sL https://github.com/spack/spack/pull/40557.patch | patch -p1 \
+    && curl -sL https://github.com/spack/spack/pull/40561.patch | patch -p1 \
+    && spack install intel-oneapi-compilers-classic \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'conda_channel') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'debugger') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name '*32*') \
+    && rm -rf /opt/intel /tmp/*
+    && spack clean -a \
+    && rm -rf /root/.spack ; fi
+
 # Sign the buildcache
 RUN --mount=type=secret,id=bootstrap_gcc_key \
     mkdir -p $(dirname "${SPACK_ROOT}") \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -150,10 +150,10 @@ RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}"
     && spack install intel-oneapi-compilers@2024.1.0 \
     && . "$(spack location -i intel-oneapi-compilers)"/setvars.sh \
     && spack compiler add --scope site \
-    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'conda_channel') \
-    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'debugger') \
-    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name '*32*') \
-    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'oclfpga') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -mindepth 1 -type d -name 'conda_channel') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -mindepth 1 -type d -name 'debugger') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -mindepth 1 -type d -name '*32*') \
+    && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -mindepth 1 -type d -name 'oclfpga') \
     && rm -rf /opt/intel /tmp/* \
     && spack clean -a \
     && rm -rf /root/.spack ; fi

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -111,13 +111,11 @@ RUN curl -sOL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTAL
 # Bootstrap spack compiler installation into the eventual installation tree
 # Defined in spack/share/spack/gitlab/cloud_pipelines/configs/config.yaml
 ARG SPACK_ROOT="/bootstrap-compilers/spack"
-#  commit after https://github.com/spack/spack/pull/34821
-ARG SPACK_COMMIT=f27d012
+ARG SPACK_TAG="v0.22.2"
 ARG TARGETARCH
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \
-    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
-    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && git clone -b ${SPACK_TAG} https://github.com/spack/spack "${SPACK_ROOT}" \
     && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "${SPACK_ROOT}/etc/spack/config.yaml" \
     && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "/bootstrap/cloud_pipelines-config.yaml" \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
@@ -129,8 +127,7 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
 # Sign the buildcache
 RUN --mount=type=secret,id=bootstrap_gcc_key \
     mkdir -p $(dirname "${SPACK_ROOT}") \
-    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
-    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && git clone -b ${SPACK_TAG} https://github.com/spack/spack "${SPACK_ROOT}" \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack gpg trust /run/secrets/bootstrap_gcc_key \
     && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
@@ -141,7 +138,6 @@ RUN --mount=type=secret,id=bootstrap_gcc_key \
 
 # Add oneapi compiler into container. The stack can pick up the compilers by using ${SPACK_ROOT}/etc/spack/compilers.yaml
 # intel-oneapi-compiler@2024.1.0 is the last version compatible with AL2 glibc 2.26
-ARG SPACK_TAG="v0.22.0"
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone --depth=1 -b ${SPACK_TAG} https://github.com/spack/spack.git "${SPACK_ROOT}" \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -111,7 +111,7 @@ RUN curl -sOL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTAL
 # Bootstrap spack compiler installation into the eventual installation tree
 # Defined in spack/share/spack/gitlab/cloud_pipelines/configs/config.yaml
 ARG SPACK_ROOT="/bootstrap-compilers/spack"
-ARG SPACK_TAG="v0.22.2"
+ARG SPACK_TAG="develop-2024-07-07"
 ARG TARGETARCH
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -139,9 +139,9 @@ RUN --mount=type=secret,id=bootstrap_gcc_key \
     && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
-# Add intel compiler by using a constant git tag. Leave the spack installation to enable
-# `spack install intel-oneapi-compiler` during container bootstrap.
-ARG SPACK_TAG="develop-2023-08-06"
+# Add oneapi compiler into container. The stack can pick up the compilers by using ${SPACK_ROOT}/etc/spack/compilers.yaml
+# intel-oneapi-compiler@2024.1.0 is the last version compatible with AL2 glibc 2.26
+ARG SPACK_TAG="v0.22.0"
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}") \
     && git clone --depth=1 -b ${SPACK_TAG} https://github.com/spack/spack.git "${SPACK_ROOT}" \
@@ -150,11 +150,10 @@ RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}"
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack load gcc \
     && spack compiler add --scope site \
-    && spack external find --scope site --tag core-packages \
     && cd "${SPACK_ROOT}" \
-    && curl -sL https://github.com/spack/spack/pull/40557.patch | patch -p1 \
-    && curl -sL https://github.com/spack/spack/pull/40561.patch | patch -p1 \
-    && spack install intel-oneapi-compilers-classic \
+    && spack install intel-oneapi-compilers@2024.1.0 \
+    && . "$(spack location -i intel-oneapi-compilers)"/setvars.sh \
+    && spack compiler add --scope site \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'conda_channel') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name 'debugger') \
     && rm -rf $(find $(spack find --format '{prefix}' intel-oneapi-compilers) -type d -name '*32*') \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -128,9 +128,21 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
+# Sign the buildcache
+RUN --mount=type=secret,id=bootstrap_gcc_key \
+    mkdir -p $(dirname "${SPACK_ROOT}") \
+    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
+    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
+    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
+    && spack gpg trust /run/secrets/bootstrap_gcc_key \
+    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
+    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
+    && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
+    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \
+    && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
+
 # Add intel compiler by using a constant git tag. Leave the spack installation to enable
 # `spack install intel-oneapi-compiler` during container bootstrap.
-ARG SPACK_ROOT="/bootstrap-compilers/spack"
 ARG SPACK_TAG="develop-2023-08-06"
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}") \
@@ -152,19 +164,6 @@ RUN if [[ "amd64" == "${TARGETARCH}" ]]; then mkdir -p $(dirname "${SPACK_ROOT}"
     && rm -rf /opt/intel /tmp/* \
     && spack clean -a \
     && rm -rf /root/.spack ; fi
-
-# Sign the buildcache
-RUN --mount=type=secret,id=bootstrap_gcc_key \
-    mkdir -p $(dirname "${SPACK_ROOT}") \
-    && git clone https://github.com/spack/spack "${SPACK_ROOT}" \
-    && pushd "${SPACK_ROOT}" && git checkout ${SPACK_COMMIT} && popd \
-    && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
-    && spack gpg trust /run/secrets/bootstrap_gcc_key \
-    && secretkey_fingerprint=$(GNUPGHOME="${SPACK_ROOT}"/opt/spack/gpg gpg2 -K --with-fingerprint --with-colons | awk -F: '/fpr/{print $10}') \
-    && ls /bootstrap-gcc-cache/build_cache/*json | xargs -I {} spack gpg sign --output {}.sig --key ${secretkey_fingerprint} --clearsign {} \
-    && spack mirror add bootstrap-gcc-cache /bootstrap-gcc-cache \
-    && spack gpg publish --rebuild-index -m bootstrap-gcc-cache ${secretkey_fingerprint} \
-    && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 ENV PATH=/bootstrap/runner/view/bin:$PATH \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -122,8 +122,6 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "/bootstrap/cloud_pipelines-config.yaml" \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack compiler add \
-    && spack external find \
-    && spack tags build-tools | xargs -I {} spack config rm packages:{} \
     && spack install gcc \
     && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack

--- a/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
@@ -1,5 +1,8 @@
 ---  # GCC setup for all AMD64 based targets
 packages:
   gcc:
-    compiler: [gcc]
     require: "gcc@12 +strip +binutils ^binutils@2.37 target=x86_64_v3"
+  intel-oneapi-compilers:
+    require: "intel-oneapi-compilers %gcc target=x86_64_v3"
+  all:
+    compiler: [gcc]


### PR DESCRIPTION
- This image is intended only to be used within the spack gitlab runners.
- Remove as much as possible after installation to minimize image size.