### PR TITLE
Create Ubuntu 24.04 image

### DIFF
--- a/Dockerfiles/ubuntu-24.04.dockerfile
+++ b/Dockerfiles/ubuntu-24.04.dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt update -y \
+  && apt upgrade -y \
+  && apt install -y \
+  autoconf \
+  automake \
+  bzip2 \
+  cpio \
+  curl \
+  file \
+  findutils \
+  g++ \
+  gcc \
+  gettext \
+  gfortran \
+  git \
+  gpg \
+  iputils-ping \
+  jq \
+  libffi-dev \
+  libssl-dev \
+  libxml2-dev \
+  locales \
+  locate \
+  m4 \
+  make \
+  mercurial \
+  ncurses-dev \
+  patch \
+  patchelf \
+  pciutils \
+  python3-pip \
+  rsync \
+  unzip \
+  wget \
+  zlib1g-dev \
+  && locale-gen en_US.UTF-8 \
+  && apt autoremove --purge \
+  && apt clean \
+  && ln -s /usr/bin/gpg /usr/bin/gpg2 \
+  && ln -s `which python3` /usr/bin/python
+
+RUN python -m pip install --upgrade pip setuptools wheel \
+ && python -m pip install gnureadline boto3 pyyaml pytz minio requests clingo \
+ && rm -rf ~/.cache
+
+CMD ["/bin/bash"]
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LANGUAGE=en_US:en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8


### PR DESCRIPTION
TF only builds with GCC 12+, hoping Ubuntu 24 has a new enough compiler.

@aweits