### PR TITLE
pcluster-amazonlinux-2 version bump

### DIFF
--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -120,8 +120,8 @@ RUN mkdir -p $(dirname "${SPACK_ROOT}") \
     && cp "${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/configs/config.yaml" "/bootstrap/cloud_pipelines-config.yaml" \
     && . "${SPACK_ROOT}/share/spack/setup-env.sh" \
     && spack compiler add \
-    && spack install gcc \
-    && spack buildcache create -a -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
+    && spack install gcc@12 \
+    && spack buildcache create -u /bootstrap-gcc-cache $(spack find --format '/{hash}') \
     && rm -rf $(dirname "${SPACK_ROOT}") /root/.spack
 
 # Sign the buildcache

--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -111,7 +111,7 @@ RUN curl -sOL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTAL
 # Bootstrap spack compiler installation into the eventual installation tree
 # Defined in spack/share/spack/gitlab/cloud_pipelines/configs/config.yaml
 ARG SPACK_ROOT="/bootstrap-compilers/spack"
-ARG SPACK_TAG="develop-2024-07-07"
+ARG SPACK_TAG="develop-2025-04-13"
 ARG TARGETARCH
 COPY Dockerfiles/pcluster-amazonlinux-2/${TARGETARCH}/packages.yaml /root/.spack/packages.yaml
 RUN mkdir -p $(dirname "${SPACK_ROOT}") \

--- a/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/amd64/packages.yaml
@@ -1,8 +1,15 @@
 ---  # GCC setup for all AMD64 based targets
 packages:
   gcc:
-    require: "gcc@12 +strip +binutils ^binutils@2.37 target=x86_64_v3"
+    require:
+    # binutils is required so that the linker is able to understand the proper
+    # cpu flags that newer gcc emits.
+    - any_of: ["+strip +binutils ^binutils@2.37 target=x86_64_v3"]
+    # don't enforce our gcc requirements on the external os gcc.  Do this by
+    # requiring only newer gcc to match the spec we require.
+      when: "@12:"
   intel-oneapi-compilers:
     require: "intel-oneapi-compilers %gcc target=x86_64_v3"
   all:
-    compiler: [gcc]
+    prefer:
+    - "%gcc"

--- a/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
+++ b/Dockerfiles/pcluster-amazonlinux-2/arm64/packages.yaml
@@ -1,5 +1,10 @@
 ---  # GCC setup for all ARM64 based targets
 packages:
   gcc:
-    compiler: [gcc]
-    require: "gcc@12 +strip +binutils ^binutils@2.37 target=aarch64"
+    require:
+    # binutils is required so that the linker is able to understand the proper
+    # cpu flags that newer gcc emits.
+    - any_of: ["+strip +binutils ^binutils@2.37 target=aarch64"]
+    # don't enforce our gcc requirements on the external os gcc.  Do this by
+    # requiring only newer gcc to match the spec we require.
+      when: "@12:"


### PR DESCRIPTION
Update the tagged spack version for bootstrapping the compiler, so that includes compilers-as-nodes, and make packages.yaml compatible with that version.