### PR TITLE
Add clang/flang to Ubuntu 24 images

### DIFF
--- a/Dockerfiles/ubuntu-24.04.dockerfile
+++ b/Dockerfiles/ubuntu-24.04.dockerfile
@@ -9,10 +9,12 @@ RUN apt update -y \
   autoconf \
   automake \
   bzip2 \
+  clang \
   cpio \
   curl \
   file \
   findutils \
+  flang \
   g++ \
   gcc \
   gettext \


### PR DESCRIPTION
TF/JAX only support Clang, I'm tired of fighting against GCC build issues.