### PR TITLE
Add llvm-config to Ubuntu 24 images

### DIFF
--- a/Dockerfiles/ubuntu-24.04.dockerfile
+++ b/Dockerfiles/ubuntu-24.04.dockerfile
@@ -26,6 +26,7 @@ RUN apt update -y \
   libffi-dev \
   libssl-dev \
   libxml2-dev \
+  llvm-dev \
   locales \
   locate \
   m4 \


### PR DESCRIPTION
Follow-up to #63 

It seems that if clang/flang are installed, Spack will register an external LLVM and use that instead of building LLVM. However, anything calling `spec['llvm'].libs` runs `llvm-config`, which is not installed on the image. This PR hopefully adds `llvm-config` to the image, although I have no idea how to test this. Suggestions for better solutions are welcome.

@rbberger