### PR TITLE
Hide the system GPG in pcluster

### DIFF
--- a/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
+++ b/Dockerfiles/pcluster-amazonlinux-2/Dockerfile
@@ -48,6 +48,10 @@ RUN yum update -y \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
+# Need to hide the system gpg
+RUN mkdir -p /usr/bin/xgpg/ \
+    && mv /usr/bin/gpg* /usr/bin/xgpg/
+
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install gnureadline 'boto3<=1.20.35' 'botocore<=1.23.46' pyyaml pytz minio requests clingo \
  && rm -rf ~/.cache


### PR DESCRIPTION
yum and gpgme are the only system tools that need GPG. Since neither of these should be used by Spack CI it should be safe to hide the system GPG and force Spack to bootstrap a newer GPG from the github mirrors.